### PR TITLE
New timestamp and sender

### DIFF
--- a/config/Sony.php
+++ b/config/Sony.php
@@ -6,6 +6,7 @@ return [
         'enabled'       => true,
         'sender_map'    => [
             '/no-reply@snei.sony.com/',
+            '/no-reply@sie.sony.com/',
         ],
         'body_map'      => [
             //

--- a/src/Sony.php
+++ b/src/Sony.php
@@ -39,7 +39,7 @@ class Sony extends Parser
             if (strpos($subject, 'were blacklisted from the PlayStation Network') !== false){
                 $bodyLines = explode("\n",$body);
                 foreach($bodyLines as $line){
-                    if (preg_match('/(\d{4}-\d{2}-\d{2} \d{2}:\d{2}) ~ (\d{4}-\d{2}-\d{2} \d{2}:\d{2}) \(UTC\),\s+([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}),\s+(.+)/',
+                    if (preg_match('/(\d{4}-\d{2}-\d{2} \d{2}:\d{2}(?::\d{2})?) ~ (\d{4}-\d{2}-\d{2} \d{2}:\d{2}(?::\d{2})?) \(UTC\),\s+([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}),\s+(.+)/',
                         $line,
                         $matches)){
                         $report = [


### PR DESCRIPTION
Adds support for the new timestamp that includes seconds, i.e.

2020-12-08 13:59:00 ~ 2020-12-08 14:59:00 (UTC),    198.51.100.25, Account Takeover Attempts

Keeping the "second less" timestamp as an option for backwards compatibility.

Also adds a new source to sender_map to make this work.